### PR TITLE
Add a vim version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Both schemes are packed in the same package.
 ## Variations
 
 - Version for Visual Studio Code [tonsky/vscode-theme-alabaster](https://github.com/tonsky/vscode-theme-alabaster)
+- Version for Vim [agudulin/vim-colors-alabaster](https://github.com/agudulin/vim-colors-alabaster)
 - Alternative version for Sublime Text 2 [freetonik/Travertine](https://github.com/freetonik/Travertine)
 - Dark version for VS Code [apust/vscode-rubber-theme](https://github.com/apust/vscode-rubber-theme)
 - Original version for LigthTable [tonsky/alabaster-lighttable-skin](https://github.com/tonsky/alabaster-lighttable-skin)


### PR DESCRIPTION
I've ported this color theme to vim (running inside iterm).

<img width="1130" alt="iterm-vim" src="https://user-images.githubusercontent.com/492261/50384707-c3d12400-06c8-11e9-913f-c6dd61317e9c.png">

Adding a link in readme to the list of variations.