### PR TITLE
Add background highlighting for constants

### DIFF
--- a/Alabaster BG.sublime-color-scheme
+++ b/Alabaster BG.sublime-color-scheme
@@ -45,17 +45,15 @@
         {"name":       "Strings",
          "scope":      "string",
          "background": "var(green)"},
-        
+
         {"name":       "Escapes",
          "scope":      "constant.character.escape, constant.other.placeholder",
          "background": "var(dark_green)"},
 
-        // {"name":       "Constants",
-        //  "scope":      "constant",
-        //  "background": "var(magenta)"},
         {"name":       "Constants",
-         "scope":      "constant, punctuation.definition.constant",
-         "foreground": "#7A3E9D"},
+         "scope":      "constant, constant.numeric, constant.language, punctuation.definition.constant",
+         "foreground": "var(fg)",
+         "background": "var(magenta)"},
 
         {"name":       "Definitions",
          "scope":      "entity.name - entity.name.tag",
@@ -73,13 +71,13 @@
          "scope":      "invalid, invalid string, invalid constant, invalid entity.name, invalid punctuation, invalid source.symbol",
          "foreground": "#c33",
          "background": "var(red)"},
-         
+
         {"scope": "markup.inserted",
          "foreground": "hsl(100, 50%, 50%)"},
 
         {"scope": "markup.deleted",
          "foreground": "hsl(2, 65%, 50%)"},
-         
+
         {"scope": "markup.changed",
          "foreground": "hsl(30, 85%, 50%)"},
 


### PR DESCRIPTION
- general scope
- numeric,
- language
- punctuation.definition.constant

## Preview
<img width="1003" alt="image" src="https://user-images.githubusercontent.com/3941/65719709-caf5ea00-e0bf-11e9-9142-d8d06142a56a.png">

