### PR TITLE
Make selection more visible in Dark theme

### DIFF
--- a/Alabaster Dark.sublime-color-scheme
+++ b/Alabaster Dark.sublime-color-scheme
@@ -13,7 +13,7 @@
         "caret":                       "var(active)",
         "line_highlight":              "#ffffff10",
         "misspelling":                 "#f00",
-        "selection":                   "#ffffff10",
+        "selection":                   "#3c4c4d",
         "selection_border_width":      "0",
         "selection_corner_radius":     "2",
         "highlight":                   "var(active)",


### PR DESCRIPTION
Currently, Alabaster Dark is barely usable because the selection is almost the same color as the background (see the screenshot https://imgur.com/a/oXBmGWl)

I've made it a bit lighter but not too light so that the theme remains dark (see https://imgur.com/a/mJm4dRk).