### PR TITLE
fix definitions' and constants' colors in dark scheme

### DIFF
--- a/Alabaster Dark.sublime-color-scheme
+++ b/Alabaster Dark.sublime-color-scheme
@@ -47,11 +47,11 @@
 
         {"name":       "Constants",
          "scope":      "constant, punctuation.definition.constant",
-         "foreground": "#71ADE7"},
+         "foreground": "#CC8BC9"},
 
         {"name":       "Definitions",
          "scope":      "entity.name - entity.name.tag",
-         "foreground": "#CC8BC9"},
+         "foreground": "#71ADE7"},
 
         {"name":       "Punctuation",
          "scope":      "punctuation - punctuation.section, keyword.operator, string punctuation.section",


### PR DESCRIPTION
Light variant:
<img width="732" alt="Screenshot 2021-04-03 at 15 39 35" src="https://user-images.githubusercontent.com/711514/113478660-e3a04680-9492-11eb-8a21-d8f5df765dab.png">

Dark variant before this change:
<img width="732" alt="Screenshot 2021-04-03 at 15 39 52" src="https://user-images.githubusercontent.com/711514/113478666-e9962780-9492-11eb-9aa3-0f47040c1973.png">

Dark variant after this change:
<img width="732" alt="Screenshot 2021-04-03 at 15 39 58" src="https://user-images.githubusercontent.com/711514/113478669-eef37200-9492-11eb-9108-4388764427da.png">

See also:
- https://twitter.com/zemlanin/status/1378322847244947458
- https://twitter.com/nikitonsky/status/1378323154435719168