### PR TITLE
Add Helix editor port to variations list

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Then, enable it:
 - for Kitty Terminal [anmolmathias/kitty-alabaster](https://github.com/anmolmathias/kitty-alabaster)
 - for Warp Terminal [arsenydubrovin/warp-alabaster-theme](https://github.com/arsenydubrovin/warp-alabaster-theme)
 - for Zed [tsimoshka/zed-theme-alabaster](https://github.com/tsimoshka/zed-theme-alabaster)
+- for Helix [wolf/alabaster-for-helix](https://github.com/wolf/alabaster-for-helix)
 
 ## See also
 


### PR DESCRIPTION
Hi Nikita,

I've created a port of Alabaster for the Helix editor. Helix is a modern modal text editor written in Rust that's gaining popularity in the development community.

The port faithfully implements the Alabaster philosophy with both light and dark variants, highlighting only the four essential categories (strings, constants, comments, and definitions) while keeping everything else in the default foreground color.

Repository: https://github.com/wolf/alabaster-for-helix

I ported the basics:
  - `wolf-alabaster-light`
  - `wolf-alabaster-dark`
  
I didn't make BG or Mono variants. Should I?

Before creating this port, there wasn't a good Alabaster implementation for Helix, and since many developers are switching to Helix, I wanted to bring your excellent minimal highlighting philosophy to this editor.

Thank you for creating Alabaster and maintaining this list of ports!  wolf-alabaster-light is my default theme now.